### PR TITLE
Forge/simulation2

### DIFF
--- a/core/src/pbs/delayer.rs
+++ b/core/src/pbs/delayer.rs
@@ -1,12 +1,34 @@
-use std::sync::RwLock;
 use {
     crate::{
         banking_trace::{BankingPacketBatch, BankingPacketSender},
-        pbs::{filters::SubscriptionFilters, grpc::PbsBatch, slot_boundary::SlotBoundaryStatus},
+        pbs::{
+            filters::SubscriptionFilters,
+            grpc::{PbsBatch, SanitizedTransactionWithSimulationResult, SimulationResult},
+            slot_boundary::SlotBoundaryStatus,
+        },
     },
-    std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
+    crossbeam_channel::SendError,
+    futures::StreamExt,
+    solana_accounts_db::transaction_results::InnerInstructionsList,
+    solana_bundle::bundle_execution::{
+        load_and_execute_bundle, LoadAndExecuteBundleError, LoadAndExecuteBundleResult,
+    },
+    solana_measure::measure_us,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_sdk::{
+        bundle::{derive_bundle_id_from_sanitized_transactions, SanitizedBundle},
+        clock::MAX_PROCESSING_AGE,
+        saturating_add_assign,
+        transaction::{MessageHash, SanitizedTransaction},
+    },
+    std::{
+        collections::VecDeque,
+        slice::from_ref,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        time::Duration,
     },
     tokio::{
         sync::{
@@ -14,27 +36,222 @@ use {
             watch,
         },
         task::JoinHandle,
-        time::Instant,
+        time::{interval, Instant},
     },
+    tokio_util::time::DelayQueue,
 };
-use solana_runtime::bank_forks::BankForks;
+
+const SIMULATION_DEADLINE_MS: u64 = 200;
+const DELAY_PACKET_BATCHES_MS: u64 = 300;
+
+const SIMULATION_CHUNK_SIZE: usize = 20;
+const MAX_TX_SIMULATION_TIME_MS: u64 = 10;
 
 pub type TimestampedBankingPacketBatch = (BankingPacketBatch, Instant);
+
+#[derive(Default)]
+struct PbsDelayerStageStats {
+    num_sanitized_txs: u64,
+    num_filtered_txs: u64,
+    num_empty_batches: u64,
+    num_simulated_chunks: u64,
+    num_simulated_txs: u64,
+    simulation_us: u64,
+
+    num_failed_sims: u64,
+    num_proc_time_exceeded_sims: u64,
+    num_lock_err_sims: u64,
+    num_success_sims: u64,
+
+    num_missing_delay_deadlines: u64,
+    num_missing_sim_deadlines: u64,
+    num_unprocessed_txs: u64,
+}
+
+impl PbsDelayerStageStats {
+    pub(crate) fn report(&self) {
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_sanitized_txs", self.num_sanitized_txs, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_filtered_txs", self.num_filtered_txs, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_empty_batches", self.num_empty_batches, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_simulated_chunks", self.num_simulated_chunks, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("simulation_us", self.simulation_us, i64),
+        );
+
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_failed_sims", self.num_failed_sims, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            (
+                "num_proc_time_exceeded_sims",
+                self.num_proc_time_exceeded_sims,
+                i64
+            ),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_lock_err_sims", self.num_lock_err_sims, i64),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_success_sims", self.num_success_sims, i64),
+        );
+
+        datapoint_info!(
+            "pbs_delayer-stats",
+            (
+                "num_missing_delay_deadlines",
+                self.num_missing_delay_deadlines,
+                i64
+            ),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            (
+                "num_missing_sim_deadlines",
+                self.num_missing_sim_deadlines,
+                i64
+            ),
+        );
+        datapoint_info!(
+            "pbs_delayer-stats",
+            ("num_unprocessed_txs", self.num_unprocessed_txs, i64),
+        );
+    }
+}
 
 pub struct PacketDelayer {
     receiver: UnboundedReceiver<TimestampedBankingPacketBatch>,
     banking: BankingPacketSender,
     pbs: UnboundedSender<PbsBatch>,
     slot_boundary_watch: watch::Receiver<SlotBoundaryStatus>,
-    connection_watch: watch::Receiver<bool>,
-    filters_watch: watch::Receiver<Option<SubscriptionFilters>>,
+    connection_watch: watch::Receiver<Option<SubscriptionFilters>>,
     bank_forks: Arc<RwLock<BankForks>>,
     exit: Arc<AtomicBool>,
 }
 
-async fn run_delayer(mut actor: PacketDelayer) {
-    while !actor.exit.load(Ordering::Relaxed) {
-        todo!()
+async fn run_delayer(actor: PacketDelayer) {
+    let PacketDelayer {
+        mut receiver,
+        banking,
+        pbs,
+        mut slot_boundary_watch,
+        mut connection_watch,
+        bank_forks,
+        exit,
+    } = actor;
+
+    let mut stats = PbsDelayerStageStats::default();
+    let mut slot_boundary_status = *slot_boundary_watch.borrow_and_update();
+    let mut connection_state = connection_watch.borrow_and_update().clone();
+    let mut unprocessed_batches = VecDeque::new();
+    let mut delay_queue = DelayQueue::new();
+    let mut metrics_tick = interval(Duration::from_secs(1));
+
+    while !exit.load(Ordering::Relaxed) {
+        tokio::select! {
+            biased;
+
+            maybe_slot_boundary_changed = slot_boundary_watch.changed() => {
+                if maybe_slot_boundary_changed.is_err() {
+                    error!("slot boundary checker updater closed");
+                    break;
+                }
+                slot_boundary_status = *slot_boundary_watch.borrow_and_update();
+            }
+
+            maybe_connection_changed = connection_watch.changed() => {
+                if maybe_connection_changed.is_err() {
+                    error!("pbs connection updater closed");
+                    break;
+                }
+                connection_state = connection_watch.borrow_and_update().clone();
+                if connection_state.is_none() {
+                    if immediately_forward(&banking, &mut unprocessed_batches).is_err() {
+                        error!("banking receiver closed");
+                        break;
+                    }
+                }
+            }
+
+            Some(packet_batch) = receiver.recv() => {
+                let batch = match (&connection_state, is_deadline_elapsed(&packet_batch, Duration::from_millis(DELAY_PACKET_BATCHES_MS))) {
+                    (Some(filters), false) => {
+                        PacketBatchInProcess::sanitize_and_filter(&packet_batch, bank_forks.as_ref(), filters, &mut stats)
+                    }
+                    (_, true) => {
+                        saturating_add_assign!(stats.num_missing_delay_deadlines, 1);
+                        None
+                    }
+                    _ => None
+                };
+                if let Some(batch) = batch {
+                    unprocessed_batches.push_back(batch);
+                } else if banking.send(packet_batch.0).is_err() {
+                    error!("banking receiver closed");
+                    break;
+                }
+            }
+
+            Some(maybe_batch) = delay_queue.next() => {
+                // TODO: filter out bundle packets
+                match maybe_batch {
+                    Ok(batch) => {
+                        if banking.send(batch.into_inner()).is_err() {
+                            error!("banking packet receiver closed");
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        warn!("delay queue error: {}", err);
+                    }
+                }
+            }
+
+            _ = metrics_tick.tick() => {
+                stats.report();
+                stats = PbsDelayerStageStats::default();
+            }
+
+            Some(batch) = futures::future::ready(unprocessed_batches.front_mut()) => {
+                let pbs_batch = {
+                    let bank = bank_forks.read().unwrap().working_bank();
+                    batch.simulate_chunk(bank.as_ref(), SIMULATION_CHUNK_SIZE, &mut stats)
+                };
+                if pbs.send(pbs_batch).is_err() {
+                    error!("pbs receiver closed");
+                    break;
+                }
+                if batch.is_empty() || batch.is_simulation_deadline_elapsed() {
+                    if let Some(PacketBatchInProcess {banking_packet_batch, delay_deadline, unprocessed, ..}) = unprocessed_batches.pop_front() {
+                        delay_queue.insert_at(banking_packet_batch, delay_deadline);
+                        if !unprocessed.is_empty() {
+                            saturating_add_assign!(stats.num_missing_sim_deadlines, 1);
+                            saturating_add_assign!(stats.num_unprocessed_txs, unprocessed.len() as u64);
+                            if pbs.send(unprocessed.into_iter().map(Into::into).collect()).is_err() {
+                                error!("pbs receiver closed");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -44,8 +261,7 @@ impl PacketDelayer {
         banking: BankingPacketSender,
         pbs: UnboundedSender<PbsBatch>,
         slot_boundary_watch: watch::Receiver<SlotBoundaryStatus>,
-        connection_watch: watch::Receiver<bool>,
-        filters_watch: watch::Receiver<Option<SubscriptionFilters>>,
+        connection_watch: watch::Receiver<Option<SubscriptionFilters>>,
         bank_forks: Arc<RwLock<BankForks>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
@@ -55,11 +271,169 @@ impl PacketDelayer {
             pbs,
             slot_boundary_watch,
             connection_watch,
-            filters_watch,
             bank_forks,
             exit,
         };
 
         tokio::spawn(run_delayer(actor))
     }
+}
+
+struct PacketBatchInProcess {
+    banking_packet_batch: BankingPacketBatch,
+    simulation_deadline: Instant,
+    delay_deadline: Instant,
+    unprocessed: Vec<SanitizedTransaction>,
+}
+
+impl PacketBatchInProcess {
+    pub fn is_simulation_deadline_elapsed(&self) -> bool {
+        Instant::now() > self.simulation_deadline
+    }
+
+    pub fn sanitize_and_filter(
+        batch: &TimestampedBankingPacketBatch,
+        bank_forks: &RwLock<BankForks>,
+        filters: &SubscriptionFilters,
+        stats: &mut PbsDelayerStageStats,
+    ) -> Option<Self> {
+        let (banking_packet_batch, start) = batch;
+        let simulation_deadline = *start + Duration::from_millis(SIMULATION_DEADLINE_MS);
+        let delay_deadline = *start + Duration::from_millis(DELAY_PACKET_BATCHES_MS);
+        assert!(delay_deadline > simulation_deadline);
+
+        let mut num_sanitized_txs = 0u64;
+        let bank = bank_forks.read().unwrap().working_bank();
+        let unprocessed: Vec<_> = banking_packet_batch
+            .0
+            .iter()
+            .flat_map(|batch| {
+                batch.iter().filter_map(|packet| {
+                    let tx = packet.deserialize_slice(..).ok()?;
+                    SanitizedTransaction::try_create(tx, MessageHash::Compute, None, bank.as_ref())
+                        .ok()
+                })
+            })
+            .inspect(|_| num_sanitized_txs += 1)
+            .filter(|tx| filters.is_tx_have_to_be_processed(tx))
+            .collect();
+
+        saturating_add_assign!(stats.num_sanitized_txs, num_sanitized_txs);
+        saturating_add_assign!(stats.num_filtered_txs, unprocessed.len() as u64);
+
+        if unprocessed.is_empty() {
+            saturating_add_assign!(stats.num_empty_batches, 1);
+            return None;
+        }
+
+        Some(PacketBatchInProcess {
+            banking_packet_batch: banking_packet_batch.clone(),
+            simulation_deadline,
+            delay_deadline,
+            unprocessed,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.unprocessed.is_empty()
+    }
+
+    pub fn simulate_chunk(
+        &mut self,
+        bank: &Bank,
+        chunk_size: usize,
+        stats: &mut PbsDelayerStageStats,
+    ) -> Vec<SanitizedTransactionWithSimulationResult> {
+        let start = self.unprocessed.len().saturating_sub(chunk_size);
+        let batch: Vec<_> = self
+            .unprocessed
+            .drain(start..)
+            .map(|tx| {
+                let (simulation_result, simulation_us) = measure_us!(simulate(&tx, bank));
+                saturating_add_assign!(stats.simulation_us, simulation_us);
+                collect_simulation_stats(&simulation_result, stats);
+                SanitizedTransactionWithSimulationResult::new(tx, simulation_result)
+            })
+            .collect();
+
+        saturating_add_assign!(stats.num_simulated_chunks, 1);
+        saturating_add_assign!(stats.num_simulated_txs, batch.len() as u64);
+
+        batch
+    }
+}
+
+fn collect_simulation_stats(tx: &SimulationResult, stats: &mut PbsDelayerStageStats) {
+    match tx {
+        Ok(_) => saturating_add_assign!(stats.num_success_sims, 1),
+        Err(LoadAndExecuteBundleError::ProcessingTimeExceeded(_)) => {
+            saturating_add_assign!(stats.num_proc_time_exceeded_sims, 1)
+        }
+        Err(LoadAndExecuteBundleError::LockError { .. }) => {
+            saturating_add_assign!(stats.num_lock_err_sims, 1)
+        }
+        Err(LoadAndExecuteBundleError::TransactionError { .. }) => {
+            saturating_add_assign!(stats.num_failed_sims, 1)
+        }
+        _ => {}
+    }
+}
+
+fn simulate(
+    tx: &SanitizedTransaction,
+    bank: &Bank,
+) -> LoadAndExecuteBundleResult<Option<InnerInstructionsList>> {
+    const MAX_TX_SIMULATION_TIME: Duration = Duration::from_millis(MAX_TX_SIMULATION_TIME_MS);
+
+    let sanitized_bundle = SanitizedBundle {
+        bundle_id: derive_bundle_id_from_sanitized_transactions(from_ref(tx)),
+        transactions: vec![tx.clone()],
+    };
+
+    let bundle_execution_result = load_and_execute_bundle(
+        bank,
+        &sanitized_bundle,
+        MAX_PROCESSING_AGE,
+        &MAX_TX_SIMULATION_TIME,
+        true,
+        false,
+        false,
+        false,
+        &None,
+        true,
+        None,
+        &vec![None],
+        &vec![None],
+    );
+
+    bundle_execution_result.result().clone().map(|_| {
+        bundle_execution_result
+            .bundle_transaction_results()
+            .first()
+            .and_then(|bundle_execution_result| bundle_execution_result.execution_results().first())
+            .and_then(|transaction_execution_result| transaction_execution_result.details())
+            .and_then(|transaction_execution_details| {
+                transaction_execution_details.inner_instructions.as_ref()
+            })
+            .cloned()
+    })
+}
+
+fn is_deadline_elapsed(batch: &TimestampedBankingPacketBatch, duration: Duration) -> bool {
+    Instant::now() > batch.1 + duration
+}
+
+fn immediately_forward(
+    banking: &BankingPacketSender,
+    unprocessed_batches: &mut VecDeque<PacketBatchInProcess>,
+) -> Result<(), SendError<BankingPacketBatch>> {
+    for PacketBatchInProcess {
+        banking_packet_batch,
+        ..
+    } in unprocessed_batches.drain(..)
+    {
+        banking.send(banking_packet_batch)?;
+    }
+
+    Ok(())
 }

--- a/core/src/pbs/delayer.rs
+++ b/core/src/pbs/delayer.rs
@@ -1,0 +1,65 @@
+use std::sync::RwLock;
+use {
+    crate::{
+        banking_trace::{BankingPacketBatch, BankingPacketSender},
+        pbs::{filters::SubscriptionFilters, grpc::PbsBatch, slot_boundary::SlotBoundaryStatus},
+    },
+    std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    tokio::{
+        sync::{
+            mpsc::{UnboundedReceiver, UnboundedSender},
+            watch,
+        },
+        task::JoinHandle,
+        time::Instant,
+    },
+};
+use solana_runtime::bank_forks::BankForks;
+
+pub type TimestampedBankingPacketBatch = (BankingPacketBatch, Instant);
+
+pub struct PacketDelayer {
+    receiver: UnboundedReceiver<TimestampedBankingPacketBatch>,
+    banking: BankingPacketSender,
+    pbs: UnboundedSender<PbsBatch>,
+    slot_boundary_watch: watch::Receiver<SlotBoundaryStatus>,
+    connection_watch: watch::Receiver<bool>,
+    filters_watch: watch::Receiver<Option<SubscriptionFilters>>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    exit: Arc<AtomicBool>,
+}
+
+async fn run_delayer(mut actor: PacketDelayer) {
+    while !actor.exit.load(Ordering::Relaxed) {
+        todo!()
+    }
+}
+
+impl PacketDelayer {
+    pub fn start(
+        receiver: UnboundedReceiver<TimestampedBankingPacketBatch>,
+        banking: BankingPacketSender,
+        pbs: UnboundedSender<PbsBatch>,
+        slot_boundary_watch: watch::Receiver<SlotBoundaryStatus>,
+        connection_watch: watch::Receiver<bool>,
+        filters_watch: watch::Receiver<Option<SubscriptionFilters>>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        exit: Arc<AtomicBool>,
+    ) -> JoinHandle<()> {
+        let actor = PacketDelayer {
+            receiver,
+            banking,
+            pbs,
+            slot_boundary_watch,
+            connection_watch,
+            filters_watch,
+            bank_forks,
+            exit,
+        };
+
+        tokio::spawn(run_delayer(actor))
+    }
+}

--- a/core/src/pbs/filters.rs
+++ b/core/src/pbs/filters.rs
@@ -1,0 +1,87 @@
+use {
+    crate::pbs::PbsError,
+    forge_protos::proto::pbs::SubscriptionFiltersResponse,
+    solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction},
+};
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct SubscriptionFilters {
+    stream_all: bool,
+    account_include: Vec<Pubkey>,
+    account_exclude: Vec<Pubkey>,
+    account_required: Vec<Pubkey>,
+}
+
+impl TryFrom<SubscriptionFiltersResponse> for SubscriptionFilters {
+    type Error = PbsError;
+    fn try_from(value: SubscriptionFiltersResponse) -> Result<Self, Self::Error> {
+        let SubscriptionFiltersResponse {
+            stream_all,
+            account_include,
+            account_exclude,
+            account_required,
+        } = value;
+
+        Ok(Self {
+            stream_all: stream_all.unwrap_or_default(),
+            account_include: decode_pubkeys_into_vec(account_include)?,
+            account_exclude: decode_pubkeys_into_vec(account_exclude)?,
+            account_required: decode_pubkeys_into_vec(account_required)?,
+        })
+    }
+}
+
+fn decode_pubkeys_into_vec(pubkeys: Vec<Vec<u8>>) -> Result<Vec<Pubkey>, PbsError> {
+    let mut vec: Vec<_> = pubkeys
+        .into_iter()
+        .map(Pubkey::try_from)
+        .collect::<Result<_, _>>()
+        .map_err(|_| PbsError::SubscriptionFiltersError)?;
+    vec.sort();
+    Ok(vec)
+}
+
+impl SubscriptionFilters {
+    pub fn is_tx_have_to_be_processed(&self, transaction: &SanitizedTransaction) -> bool {
+        if self.stream_all {
+            return true;
+        }
+
+        let accounts = transaction.message().account_keys();
+
+        if !self.account_include.is_empty()
+            && accounts
+                .iter()
+                .all(|pubkey| self.account_include.binary_search(pubkey).is_err())
+        {
+            return false;
+        }
+
+        if !self.account_exclude.is_empty()
+            && accounts
+                .iter()
+                .any(|pubkey| self.account_exclude.binary_search(pubkey).is_ok())
+        {
+            return false;
+        }
+
+        if !self.account_required.is_empty() {
+            let mut other: Vec<&Pubkey> = accounts.iter().collect();
+
+            let is_subset = if self.account_required.len() <= other.len() {
+                other.sort();
+                self.account_required
+                    .iter()
+                    .all(|pubkey| other.binary_search(&pubkey).is_ok())
+            } else {
+                false
+            };
+
+            if !is_subset {
+                return false;
+            }
+        }
+
+        true
+    }
+}

--- a/core/src/pbs/forwarder.rs
+++ b/core/src/pbs/forwarder.rs
@@ -1,0 +1,68 @@
+use tokio::time::Instant;
+use {
+    crate::banking_trace::{BankingPacketBatch, BankingPacketReceiver, BankingPacketSender},
+    std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    tokio::{
+        sync::mpsc::UnboundedSender,
+        task::{self, JoinHandle},
+    },
+};
+
+pub struct PacketBatchesForwarder {
+    receiver: BankingPacketReceiver,
+    pbs_sender: UnboundedSender<(BankingPacketBatch, Instant)>,
+    banking_sender: BankingPacketSender,
+
+    is_pbs_active: Arc<AtomicBool>,
+    exit: Arc<AtomicBool>,
+}
+
+// Forward packets from the sigverified_receiver to the banking_packet_sender if pbs isn't ready
+fn run_packet_batch_forwarder(actor: PacketBatchesForwarder) {
+    let PacketBatchesForwarder {
+        receiver,
+        pbs_sender,
+        banking_sender,
+        is_pbs_active,
+        exit,
+    } = actor;
+
+    while !exit.load(Ordering::Relaxed) {
+        let Ok(packet_batch) = receiver.recv() else {
+            error!("sigverified packet receiver closed");
+            break;
+        };
+        if is_pbs_active.load(Ordering::Relaxed) {
+            if pbs_sender.send((packet_batch, Instant::now())).is_err() {
+                error!("pbs stage packet receiver close");
+                break;
+            }
+        } else if banking_sender.send(packet_batch).is_err() {
+            error!("banking packet sender closed");
+            break;
+        }
+    }
+}
+
+impl PacketBatchesForwarder {
+    pub fn new(
+        receiver: BankingPacketReceiver,
+        pbs_sender: UnboundedSender<BankingPacketBatch>,
+        banking_sender: BankingPacketSender,
+        is_pbs_active: Arc<AtomicBool>,
+        exit: Arc<AtomicBool>,
+    ) -> JoinHandle<()> {
+        let actor = PacketBatchesForwarder {
+            receiver,
+            pbs_sender,
+            banking_sender,
+            is_pbs_active,
+            exit,
+        };
+
+        task::spawn_blocking(move || run_packet_batch_forwarder(actor))
+    }
+}

--- a/core/src/pbs/grpc.rs
+++ b/core/src/pbs/grpc.rs
@@ -1,0 +1,107 @@
+use {
+    forge_protos::proto::pbs::{
+        transaction_with_simulation_result, BundleError as ProtoBundleError,
+        SanitizedTransaction as ProtoSanitizedTransaction,
+        SimulationResult as ProtoSimulationResult, TransactionError as ProtoTransactionError,
+    },
+    solana_accounts_db::transaction_results::InnerInstructionsList,
+    solana_bundle::bundle_execution::{LoadAndExecuteBundleError, LoadAndExecuteBundleResult},
+    solana_sdk::transaction::SanitizedTransaction,
+};
+
+pub type SimulationResult = LoadAndExecuteBundleResult<Option<InnerInstructionsList>>;
+pub type PbsBatch = Vec<SanitizedTransactionWithSimulationResult>;
+
+pub struct SanitizedTransactionWithSimulationResult {
+    pub transaction: SanitizedTransaction,
+    pub simulation_result: Option<SimulationResult>,
+}
+
+impl SanitizedTransactionWithSimulationResult {
+    pub fn new(transaction: SanitizedTransaction, simulation_result: SimulationResult) -> Self {
+        Self {
+            transaction,
+            simulation_result: Some(simulation_result),
+        }
+    }
+}
+
+impl From<SanitizedTransaction> for SanitizedTransactionWithSimulationResult {
+    fn from(transaction: SanitizedTransaction) -> Self {
+        Self {
+            transaction,
+            simulation_result: None,
+        }
+    }
+}
+
+pub fn sanitized_to_proto_sanitized(tx: SanitizedTransaction) -> Option<ProtoSanitizedTransaction> {
+    let versioned_transaction = bincode::serialize(&tx.to_versioned_transaction()).ok()?;
+    let message_hash = tx.message_hash().to_bytes().to_vec();
+    let loaded_addresses = bincode::serialize(&tx.get_loaded_addresses()).ok()?;
+
+    Some(ProtoSanitizedTransaction {
+        versioned_transaction,
+        message_hash,
+        loaded_addresses,
+    })
+}
+
+pub fn simulation_result_to_proto_simulation_result(
+    simulation_result: SimulationResult,
+) -> transaction_with_simulation_result::Simulation {
+    match simulation_result {
+        Ok(inner_instructions) => transaction_with_simulation_result::Simulation::SimulationResult(
+            inner_instructions_to_proto(inner_instructions),
+        ),
+        Err(LoadAndExecuteBundleError::ProcessingTimeExceeded(_)) => {
+            transaction_with_simulation_result::Simulation::BundleError(
+                ProtoBundleError::ProcessingTimeExceeded as i32,
+            )
+        }
+        Err(LoadAndExecuteBundleError::LockError { .. }) => {
+            transaction_with_simulation_result::Simulation::BundleError(
+                ProtoBundleError::LockError as i32,
+            )
+        }
+        Err(LoadAndExecuteBundleError::InvalidPreOrPostAccounts) => {
+            transaction_with_simulation_result::Simulation::BundleError(
+                ProtoBundleError::InvalidPreOrPostAccounts as i32,
+            )
+        }
+        Err(err @ LoadAndExecuteBundleError::TransactionError { .. }) => {
+            transaction_with_simulation_result::Simulation::TransactionError(
+                ProtoTransactionError {
+                    err: err.to_string(),
+                },
+            )
+        }
+    }
+}
+
+fn inner_instructions_to_proto(
+    inner_instructions: Option<InnerInstructionsList>,
+) -> ProtoSimulationResult {
+    use forge_protos::proto::pbs::{
+        InnerInstruction as ProtoInnerInstruction, InnerInstructions as ProtoInnerInstructions,
+    };
+
+    ProtoSimulationResult {
+        inner_instructions_none: inner_instructions.is_none(),
+        inner_instructions: inner_instructions
+            .into_iter()
+            .flatten()
+            .map(|inner_instructions| ProtoInnerInstructions {
+                instructions: inner_instructions
+                    .iter()
+                    .map(|ixn| ProtoInnerInstruction {
+                        program_id_index: ixn.instruction.program_id_index as u32,
+                        accounts: ixn.instruction.accounts.clone(),
+                        data: ixn.instruction.data.clone(),
+                        stack_height: ixn.stack_height as u32,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}

--- a/core/src/pbs/interceptor.rs
+++ b/core/src/pbs/interceptor.rs
@@ -1,4 +1,5 @@
 use {
+    solana_sdk::pubkey::Pubkey,
     solana_version::version,
     tonic::{service::Interceptor, Request, Status},
 };
@@ -6,12 +7,14 @@ use {
 pub(crate) struct AuthInterceptor {
     uuid: String,
     version: String,
+    pubkey: Pubkey,
 }
 
 impl AuthInterceptor {
-    pub(crate) fn new(uuid: String) -> Self {
+    pub(crate) fn new(uuid: String, pubkey: Pubkey) -> Self {
         Self {
             uuid,
+            pubkey,
             version: version!().to_string(),
         }
     }
@@ -25,6 +28,9 @@ impl Interceptor for AuthInterceptor {
         request
             .metadata_mut()
             .insert("version", self.version.parse().unwrap());
+        request
+            .metadata_mut()
+            .insert("validator", self.pubkey.to_string().parse().unwrap());
 
         Ok(request)
     }

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -28,4 +28,7 @@ pub enum PbsError {
 
     #[error("PacketForwardError")]
     PacketForwardError,
+
+    #[error("SlotBoundaryCheckerError")]
+    SlotBoundaryCheckerError,
 }

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -1,8 +1,13 @@
 use {thiserror::Error, tonic::Status};
 
+mod delayer;
+mod filters;
 mod forwarder;
+mod grpc;
 mod interceptor;
 pub mod pbs_stage;
+pub mod pbs_stage2;
+mod slot_boundary;
 
 #[derive(Error, Debug)]
 pub enum PbsError {
@@ -33,6 +38,6 @@ pub enum PbsError {
     #[error("SlotBoundaryCheckerError")]
     SlotBoundaryCheckerError,
 
-    #[error("SimulationSettingsError")]
-    SimulationSettingsError,
+    #[error("SubscriptionFiltersError")]
+    SubscriptionFiltersError,
 }

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -6,7 +6,6 @@ mod forwarder;
 mod grpc;
 mod interceptor;
 pub mod pbs_stage;
-pub mod pbs_stage2;
 mod slot_boundary;
 
 #[derive(Error, Debug)]

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -1,4 +1,10 @@
-use {thiserror::Error, tonic::Status};
+use {
+    solana_perf::sigverify::PacketError,
+    solana_sdk::{packet::Packet, short_vec::decode_shortu16_len, signature::Signature},
+    std::mem::size_of,
+    thiserror::Error,
+    tonic::Status,
+};
 
 mod delayer;
 mod filters;
@@ -39,4 +45,28 @@ pub enum PbsError {
 
     #[error("SubscriptionFiltersError")]
     SubscriptionFiltersError,
+}
+
+fn extract_first_signature(packet: &Packet) -> Result<Signature, PacketError> {
+    // should have at least 1 signature and sig lengths
+    let _ = 1usize
+        .checked_add(size_of::<Signature>())
+        .filter(|v| *v <= packet.meta().size)
+        .ok_or(PacketError::InvalidLen)?;
+
+    // read the length of Transaction.signatures (serialized with short_vec)
+    let (_sig_len_untrusted, sig_start) = packet
+        .data(..)
+        .and_then(|bytes| decode_shortu16_len(bytes).ok())
+        .ok_or(PacketError::InvalidShortVec)?;
+
+    let sig_end = sig_start
+        .checked_add(size_of::<Signature>())
+        .ok_or(PacketError::InvalidLen)?;
+
+    packet
+        .data(sig_start..sig_end)
+        .ok_or(PacketError::InvalidLen)?
+        .try_into()
+        .map_err(|_| PacketError::InvalidLen)
 }

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -31,4 +31,7 @@ pub enum PbsError {
 
     #[error("SlotBoundaryCheckerError")]
     SlotBoundaryCheckerError,
+
+    #[error("SimulationSettingsError")]
+    SimulationSettingsError,
 }

--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -1,5 +1,6 @@
 use {thiserror::Error, tonic::Status};
 
+mod forwarder;
 mod interceptor;
 pub mod pbs_stage;
 

--- a/core/src/pbs/pbs_stage.rs
+++ b/core/src/pbs/pbs_stage.rs
@@ -321,7 +321,7 @@ impl PbsEngineStage {
 
         let pbs_client = PbsValidatorClient::with_interceptor(
             pbs_channel,
-            AuthInterceptor::new(cluster_info.keypair().pubkey().to_string()),
+            AuthInterceptor::new(local_config.uuid.clone(), cluster_info.keypair().pubkey()),
         );
 
         Self::start_consuming(
@@ -557,6 +557,14 @@ impl PbsEngineStage {
     pub fn is_valid_pbs_config(config: &PbsConfig) -> bool {
         if config.pbs_url.is_empty() {
             warn!("can't connect to pbs. missing pbs_url.");
+            return false;
+        }
+        if config.uuid.is_empty() {
+            warn!("can't connect to pbs. missing uuid.");
+            return false;
+        }
+        if let Err(e) = tonic::metadata::MetadataValue::try_from(&config.uuid) {
+            warn!("can't connect to pbs. invalid uuid - {}", e.to_string());
             return false;
         }
         true

--- a/core/src/pbs/pbs_stage.rs
+++ b/core/src/pbs/pbs_stage.rs
@@ -1,40 +1,34 @@
 use {
     crate::{
-        banking_trace::{BankingPacketBatch, BankingPacketReceiver, BankingPacketSender},
+        banking_trace::{BankingPacketReceiver, BankingPacketSender},
         packet_bundle::PacketBundle,
-        pbs::{interceptor::AuthInterceptor, PbsError},
+        pbs::{
+            delayer::PacketDelayer,
+            filters::SubscriptionFilters,
+            forwarder::PacketBatchesForwarder,
+            grpc::{
+                sanitized_to_proto_sanitized, simulation_result_to_proto_simulation_result,
+                PbsBatch,
+            },
+            interceptor::AuthInterceptor,
+            slot_boundary::{SlotBoundaryChecker, SlotBoundaryStatus},
+            PbsError,
+        },
         proto_packet_to_packet,
     },
     crossbeam_channel::Sender,
     forge_protos::proto::pbs::{
-        pbs_validator_client::PbsValidatorClient, transaction_with_simulation_result,
-        BundleError as ProtoBundleError, BundlesResponse,
-        SanitizedTransaction as ProtoSanitizedTransaction, SanitizedTransactionRequest,
-        SimulationResult as ProtoSimulationResult, SubscriptionFiltersRequest,
-        SubscriptionFiltersResponse, TransactionError as ProtoTransactionError,
+        pbs_validator_client::PbsValidatorClient, BundlesResponse, SanitizedTransactionRequest,
+        SubscriptionFiltersRequest,
         TransactionWithSimulationResult as ProtoTransactionWithSimulationResult,
     },
-    futures::StreamExt,
     prost_types::Timestamp,
-    solana_accounts_db::transaction_results::InnerInstructionsList,
-    solana_bundle::bundle_execution::{
-        load_and_execute_bundle, LoadAndExecuteBundleError, LoadAndExecuteBundleResult,
-    },
     solana_gossip::cluster_info::ClusterInfo,
-    solana_measure::measure_us,
     solana_perf::packet::PacketBatch,
     solana_poh::poh_recorder::PohRecorder,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
-    solana_sdk::{
-        bundle::{derive_bundle_id_from_sanitized_transactions, SanitizedBundle},
-        clock::MAX_PROCESSING_AGE,
-        pubkey::Pubkey,
-        saturating_add_assign,
-        signature::Signer,
-        transaction::{MessageHash, SanitizedTransaction},
-    },
+    solana_runtime::bank_forks::BankForks,
+    solana_sdk::{saturating_add_assign, signature::Signer},
     std::{
-        slice::from_ref,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Mutex, RwLock,
@@ -43,13 +37,16 @@ use {
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
     tokio::{
-        sync::mpsc::{UnboundedReceiver, UnboundedSender},
-        task::{self, JoinHandle as TokioJoinHandle},
-        time::{interval, sleep, timeout, Instant},
+        sync::{
+            mpsc,
+            mpsc::{UnboundedReceiver, UnboundedSender},
+            watch,
+        },
+        task,
+        time::{interval, sleep, timeout},
         try_join,
     },
     tokio_stream::wrappers::UnboundedReceiverStream,
-    tokio_util::time::DelayQueue,
     tonic::{
         codegen::InterceptedService,
         transport::{Channel, Endpoint},
@@ -60,25 +57,22 @@ use {
 const CONNECTION_TIMEOUT_S: u64 = 10;
 const CONNECTION_BACKOFF_S: u64 = 5;
 
-const DELAY_PACKET_BATCHES_MS: u64 = 300;
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PbsConfig {
+    pub pbs_url: String,
+    pub uuid: String,
+}
+
+pub struct PbsEngineStage {
+    t_hdls: Vec<JoinHandle<()>>,
+}
 
 #[derive(Default)]
 struct PbsStageStats {
     num_bundles: u64,
     num_bundle_packets: u64,
-    num_missing_deadlines: u64,
     num_empty_packet_batches: u64,
-    num_sanitized_transactions: u64,
     num_empty_tx_batches: u64,
-
-    num_filtered_for_sims: u64,
-    num_failed_sims: u64,
-    num_proc_time_exceeded_sims: u64,
-    num_invalid_accs_sims: u64, // should never happen
-    num_lock_err_sims: u64,
-    num_success_simulations: u64,
-
-    simulation_us: u64,
 }
 
 impl PbsStageStats {
@@ -90,10 +84,6 @@ impl PbsStageStats {
         );
         datapoint_info!(
             "pbs_stage-stats",
-            ("num_missing_deadlines", self.num_missing_deadlines, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
             (
                 "num_empty_packet_batches",
                 self.num_empty_packet_batches,
@@ -102,55 +92,9 @@ impl PbsStageStats {
         );
         datapoint_info!(
             "pbs_stage-stats",
-            ("num_sanitized_transactions", self.num_bundles, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
             ("num_empty_tx_batches", self.num_empty_tx_batches, i64),
         );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("num_failed_sims", self.num_failed_sims, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("num_filtered_for_sims", self.num_filtered_for_sims, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            (
-                "num_proc_time_exceeded_sims",
-                self.num_proc_time_exceeded_sims,
-                i64
-            ),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("num_lock_err_sims", self.num_lock_err_sims, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("num_success_simulations", self.num_success_simulations, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("num_invalid_accs_sims", self.num_invalid_accs_sims, i64),
-        );
-        datapoint_info!(
-            "pbs_stage-stats",
-            ("simulation_us", self.simulation_us, i64),
-        );
     }
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct PbsConfig {
-    pub pbs_url: String,
-    pub uuid: String,
-}
-
-pub struct PbsEngineStage {
-    t_hdls: Vec<JoinHandle<()>>,
 }
 
 impl PbsEngineStage {
@@ -213,31 +157,32 @@ impl PbsEngineStage {
     ) {
         const CONNECTION_TIMEOUT: Duration = Duration::from_secs(CONNECTION_TIMEOUT_S);
         const CONNECTION_BACKOFF: Duration = Duration::from_secs(CONNECTION_BACKOFF_S);
-        let mut error_count: u64 = 0;
 
-        let is_pbs_active = Arc::new(AtomicBool::new(false));
-        let (forwarder_sender, forwarder_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let forwarder_join_handle = Self::start_forward_packet_batches(
+        let (mut connection_updater, connection_watch) = watch::channel(None);
+        let (forwarder_sender, delayer_receiver) = mpsc::unbounded_channel();
+        let forwarder_jh = PacketBatchesForwarder::start(
             sigverified_receiver,
             forwarder_sender,
             banking_packet_sender.clone(),
-            is_pbs_active.clone(),
+            connection_watch.clone(),
             exit.clone(),
         );
 
-        let (slot_boundary_sender, mut slot_boundary_receiver) =
-            tokio::sync::watch::channel(SlotBoundaryStatus::default());
-        let slot_boundary_checker_join_handle =
-            Self::start_slot_boundary_checker(poh_recorder, slot_boundary_sender, exit.clone());
+        let (mut slot_boundary_watch, slot_boundary_checker_jh) =
+            SlotBoundaryChecker::start(poh_recorder, exit.clone());
+        let (delayer_sender, mut pbs_receiver) = mpsc::unbounded_channel();
 
-        let (pbs_sender, mut pbs_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let delayer_join_handle = Self::start_delayer(
-            forwarder_receiver,
-            banking_packet_sender,
-            pbs_sender,
+        let delayer_jh = PacketDelayer::start(
+            delayer_receiver,
+            banking_packet_sender.clone(),
+            delayer_sender,
+            slot_boundary_watch.clone(),
+            connection_watch,
+            bank_forks,
             exit.clone(),
-            slot_boundary_receiver.clone(),
         );
+
+        let mut error_count: u64 = 0;
 
         while !exit.load(Ordering::Relaxed) {
             // Wait until a valid config is supplied (either initially or by admin rpc)
@@ -257,15 +202,21 @@ impl PbsEngineStage {
                 &bundle_tx,
                 &cluster_info,
                 &mut pbs_receiver,
-                &is_pbs_active,
+                &mut connection_updater,
                 &exit,
-                &bank_forks,
-                &mut slot_boundary_receiver,
+                &mut slot_boundary_watch,
                 &CONNECTION_TIMEOUT,
             )
             .await
             {
-                is_pbs_active.store(false, Ordering::Relaxed);
+                connection_updater.send_if_modified(|connected| {
+                    if connected.is_some() {
+                        *connected = None;
+                        true
+                    } else {
+                        false
+                    }
+                });
 
                 error_count += 1;
                 datapoint_warn!(
@@ -276,73 +227,8 @@ impl PbsEngineStage {
                 sleep(CONNECTION_BACKOFF).await;
             }
         }
-        is_pbs_active.store(false, Ordering::Relaxed);
 
-        try_join!(
-            forwarder_join_handle,
-            delayer_join_handle,
-            slot_boundary_checker_join_handle
-        )
-        .unwrap();
-    }
-
-    // Forward packets from the sigverified_receiver to the banking_packet_sender if pbs isn't ready
-    fn start_forward_packet_batches(
-        sigverified_receiver: BankingPacketReceiver,
-        pbs_sender: UnboundedSender<BankingPacketBatch>,
-        banking_packet_sender: BankingPacketSender,
-        is_pbs_active: Arc<AtomicBool>,
-        exit: Arc<AtomicBool>,
-    ) -> TokioJoinHandle<()> {
-        task::spawn_blocking(move || {
-            Self::forward_packet_batches(
-                sigverified_receiver,
-                pbs_sender,
-                banking_packet_sender,
-                is_pbs_active,
-                exit,
-            )
-        })
-    }
-
-    fn forward_packet_batches(
-        sigverified_receiver: BankingPacketReceiver,
-        pbs_sender: UnboundedSender<BankingPacketBatch>,
-        banking_packet_sender: BankingPacketSender,
-        is_pbs_active: Arc<AtomicBool>,
-        exit: Arc<AtomicBool>,
-    ) {
-        while !exit.load(Ordering::Relaxed) {
-            let Ok(packet_batch) = sigverified_receiver.recv() else {
-                error!("sigverified packet receiver closed");
-                break;
-            };
-            if is_pbs_active.load(Ordering::Relaxed) {
-                if pbs_sender.send(packet_batch).is_err() {
-                    error!("psb stage packet consumer closed");
-                    break;
-                }
-            } else if banking_packet_sender.send(packet_batch).is_err() {
-                error!("banking packet sender closed");
-                break;
-            }
-        }
-    }
-
-    fn start_delayer(
-        sigverified_receiver: UnboundedReceiver<BankingPacketBatch>,
-        banking_packet_sender: BankingPacketSender,
-        pbs_sender: UnboundedSender<(BankingPacketBatch, Instant)>,
-        exit: Arc<AtomicBool>,
-        slot_boundary_receiver: tokio::sync::watch::Receiver<SlotBoundaryStatus>,
-    ) -> TokioJoinHandle<()> {
-        tokio::spawn(Self::delay_packet_batches(
-            sigverified_receiver,
-            banking_packet_sender,
-            pbs_sender,
-            exit,
-            slot_boundary_receiver,
-        ))
+        try_join!(forwarder_jh, delayer_jh, slot_boundary_checker_jh).unwrap();
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -351,14 +237,13 @@ impl PbsEngineStage {
         global_config: &Arc<Mutex<PbsConfig>>,
         bundle_tx: &Sender<Vec<PacketBundle>>,
         cluster_info: &Arc<ClusterInfo>,
-        receiver: &mut UnboundedReceiver<(BankingPacketBatch, Instant)>,
-        is_pbs_active: &Arc<AtomicBool>,
+        receiver: &mut UnboundedReceiver<PbsBatch>,
+        connection_updater: &mut watch::Sender<Option<SubscriptionFilters>>,
         exit: &Arc<AtomicBool>,
-        bank_forks: &Arc<RwLock<BankForks>>,
-        slot_boundary_receiver: &mut tokio::sync::watch::Receiver<SlotBoundaryStatus>,
+        slot_boundary_watch: &mut watch::Receiver<SlotBoundaryStatus>,
         connection_timeout: &Duration,
     ) -> Result<(), PbsError> {
-        let mut backend_endpoint = Endpoint::from_shared(local_config.pbs_url.clone())
+        let mut endpoint = Endpoint::from_shared(local_config.pbs_url.clone())
             .map_err(|_| {
                 PbsError::PbsConnectionError(format!(
                     "invalid block engine url value: {}",
@@ -368,7 +253,7 @@ impl PbsEngineStage {
             .tcp_keepalive(Some(Duration::from_secs(60)));
 
         if local_config.pbs_url.starts_with("https") {
-            backend_endpoint = backend_endpoint
+            endpoint = endpoint
                 .tls_config(tonic::transport::ClientTlsConfig::new())
                 .map_err(|_| {
                     PbsError::PbsConnectionError(
@@ -379,13 +264,13 @@ impl PbsEngineStage {
 
         debug!("connecting to block engine: {}", local_config.pbs_url);
 
-        let pbs_channel = timeout(*connection_timeout, backend_endpoint.connect())
+        let channel = timeout(*connection_timeout, endpoint.connect())
             .await
             .map_err(|_| PbsError::PbsConnectionTimeout)?
             .map_err(|e| PbsError::PbsConnectionError(e.to_string()))?;
 
         let mut pbs_client = PbsValidatorClient::with_interceptor(
-            pbs_channel,
+            channel,
             AuthInterceptor::new(local_config.uuid.clone(), cluster_info.keypair().pubkey()),
         );
 
@@ -394,7 +279,7 @@ impl PbsEngineStage {
             pbs_client.get_subscription_filters(SubscriptionFiltersRequest {}),
         )
         .await
-        .map_err(|_| PbsError::MethodTimeout("pbs_simulation_settings".to_string()))?
+        .map_err(|_| PbsError::MethodTimeout("pbs_subscription_filters".to_string()))?
         .map_err(|e| PbsError::MethodError(e.to_string()))?
         .into_inner()
         .try_into()?;
@@ -405,12 +290,11 @@ impl PbsEngineStage {
             pbs_client,
             bundle_tx,
             receiver,
-            is_pbs_active,
+            connection_updater,
+            subscription_filters,
             exit,
-            bank_forks,
-            slot_boundary_receiver,
+            slot_boundary_watch,
             connection_timeout,
-            &subscription_filters,
         )
         .await
     }
@@ -421,42 +305,42 @@ impl PbsEngineStage {
         global_config: &Arc<Mutex<PbsConfig>>,
         mut client: PbsValidatorClient<InterceptedService<Channel, AuthInterceptor>>,
         bundle_tx: &Sender<Vec<PacketBundle>>,
-        receiver: &mut UnboundedReceiver<(BankingPacketBatch, Instant)>,
-        is_pbs_active: &Arc<AtomicBool>,
+        receiver: &mut UnboundedReceiver<PbsBatch>,
+        connection_updater: &mut watch::Sender<Option<SubscriptionFilters>>,
+        subscription_filters: SubscriptionFilters,
         exit: &Arc<AtomicBool>,
-        bank_forks: &Arc<RwLock<BankForks>>,
-        slot_boundary_receiver: &mut tokio::sync::watch::Receiver<SlotBoundaryStatus>,
+        slot_boundary_watch: &mut watch::Receiver<SlotBoundaryStatus>,
         connection_timeout: &Duration,
-        subscription_filters: &SubscriptionFilters,
     ) -> Result<(), PbsError> {
         const METRICS_TICK: Duration = Duration::from_secs(1);
 
-        let (remote_sender, remote_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let remote_receiver_stream = UnboundedReceiverStream::new(remote_receiver);
+        let (remote_sender, remote_receiver) = mpsc::unbounded_channel();
+        let stream = UnboundedReceiverStream::new(remote_receiver);
 
-        let mut bundles_stream = timeout(
-            *connection_timeout,
-            client.subscribe_sanitized(remote_receiver_stream),
-        )
-        .await
-        .map_err(|_| PbsError::MethodTimeout("pbs_subscribe".to_string()))?
-        .map_err(|e| PbsError::MethodError(e.to_string()))?
-        .into_inner();
+        let mut bundles_stream = timeout(*connection_timeout, client.subscribe_sanitized(stream))
+            .await
+            .map_err(|_| PbsError::MethodTimeout("pbs_subscribe".to_string()))?
+            .map_err(|e| PbsError::MethodError(e.to_string()))?
+            .into_inner();
 
         let mut pbs_stats = PbsStageStats::default();
         let mut retry_bundles = Vec::new();
-        let mut slot_boundary_status = *slot_boundary_receiver.borrow_and_update();
+        let mut slot_boundary_status = *slot_boundary_watch.borrow_and_update();
         let mut metrics_tick = interval(METRICS_TICK);
-        is_pbs_active.store(true, Ordering::Relaxed);
+        connection_updater
+            .send(Some(subscription_filters))
+            .map_err(|_| {
+                PbsError::PbsConnectionError("connection watchers are close".to_string())
+            })?;
 
         info!("connected to pbs stream");
-        while !exit.load(Ordering::Relaxed) {
+        while exit.load(Ordering::Relaxed) {
             tokio::select! {
                 biased;
 
-                maybe_slot_boundary_status = slot_boundary_receiver.changed() => {
+                maybe_slot_boundary_status = slot_boundary_watch.changed() => {
                     maybe_slot_boundary_status.map_err(|_| PbsError::SlotBoundaryCheckerError)?;
-                    slot_boundary_status = *slot_boundary_receiver.borrow_and_update();
+                    slot_boundary_status = *slot_boundary_watch.borrow_and_update();
                     if let SlotBoundaryStatus::InProgress = slot_boundary_status {
                         bundle_tx.send(retry_bundles).map_err(|_| PbsError::PacketForwardError)?;
                         retry_bundles = Vec::new();
@@ -471,8 +355,8 @@ impl PbsEngineStage {
                     bundle_tx.send(bundles).map_err(|_| PbsError::PacketForwardError)?;
                 }
 
-                Some((packet_batch, deadline)) = receiver.recv() => {
-                    Self::handle_packet_batch(packet_batch, deadline, &remote_sender, bank_forks, subscription_filters, &mut pbs_stats)?;
+                Some(packet_batch) = receiver.recv() => {
+                    Self::handle_packet_batch(packet_batch, &remote_sender, &mut pbs_stats)?;
                 }
 
                 _ = metrics_tick.tick() => {
@@ -521,94 +405,28 @@ impl PbsEngineStage {
     }
 
     fn handle_packet_batch(
-        packet_batches: BankingPacketBatch,
-        deadline: Instant,
+        packet_batch: PbsBatch,
         remote_sender: &UnboundedSender<SanitizedTransactionRequest>,
-        bank_forks: &Arc<RwLock<BankForks>>,
-        subscription_filters: &SubscriptionFilters,
         pbs_stats: &mut PbsStageStats,
     ) -> Result<(), PbsError> {
-        if deadline < Instant::now() {
-            saturating_add_assign!(pbs_stats.num_missing_deadlines, 1);
-            return Ok(());
-        }
-
-        if packet_batches.0.is_empty() {
+        if packet_batch.is_empty() {
             saturating_add_assign!(pbs_stats.num_empty_packet_batches, 1);
             return Ok(());
         }
 
-        let transactions_with_simulation: Vec<_> = {
-            let bank = bank_forks.read().unwrap().working_bank();
-
-            packet_batches
-                .0
-                .iter()
-                .flat_map(|batch| {
-                    batch
-                        .iter()
-                        .filter(|packet| !packet.meta().discard())
-                        .filter_map(|packet| {
-                            let tx = packet.deserialize_slice(..).ok()?;
-                            SanitizedTransaction::try_create(
-                                tx,
-                                MessageHash::Compute,
-                                None,
-                                bank.as_ref(),
-                            )
-                            .ok()
-                        })
+        let transactions_with_simulation: Vec<_> = packet_batch
+            .into_iter()
+            .filter_map(|item| {
+                let transaction = sanitized_to_proto_sanitized(item.transaction)?;
+                let simulation = item
+                    .simulation_result
+                    .map(simulation_result_to_proto_simulation_result);
+                Some(ProtoTransactionWithSimulationResult {
+                    transaction: Some(transaction),
+                    simulation,
                 })
-                .inspect(|_| saturating_add_assign!(pbs_stats.num_sanitized_transactions, 1))
-                .filter(|tx| subscription_filters.is_tx_have_to_be_processed(tx))
-                .inspect(|_| saturating_add_assign!(pbs_stats.num_filtered_for_sims, 1))
-                .filter_map(|tx| {
-                    let (simulation_result, simulation_us) =
-                        measure_us!(simulate(&tx, bank.as_ref()));
-                    saturating_add_assign!(pbs_stats.simulation_us, simulation_us);
-                    let transaction = sanitized_to_proto_sanitized(tx)?;
-
-                    let simulation = match simulation_result {
-                        Ok(simulation_result) => {
-                            saturating_add_assign!(pbs_stats.num_success_simulations, 1);
-                            transaction_with_simulation_result::Simulation::SimulationResult(
-                                simulation_result,
-                            )
-                        }
-                        Err(LoadAndExecuteBundleError::ProcessingTimeExceeded(_)) => {
-                            saturating_add_assign!(pbs_stats.num_proc_time_exceeded_sims, 1);
-                            transaction_with_simulation_result::Simulation::BundleError(
-                                ProtoBundleError::ProcessingTimeExceeded as i32,
-                            )
-                        }
-                        Err(LoadAndExecuteBundleError::LockError { .. }) => {
-                            saturating_add_assign!(pbs_stats.num_lock_err_sims, 1);
-                            transaction_with_simulation_result::Simulation::BundleError(
-                                ProtoBundleError::LockError as i32,
-                            )
-                        }
-                        Err(LoadAndExecuteBundleError::InvalidPreOrPostAccounts) => {
-                            saturating_add_assign!(pbs_stats.num_invalid_accs_sims, 1);
-                            transaction_with_simulation_result::Simulation::BundleError(
-                                ProtoBundleError::InvalidPreOrPostAccounts as i32,
-                            )
-                        }
-                        Err(err @ LoadAndExecuteBundleError::TransactionError { .. }) => {
-                            saturating_add_assign!(pbs_stats.num_failed_sims, 1);
-                            transaction_with_simulation_result::Simulation::TransactionError(
-                                ProtoTransactionError {
-                                    err: err.to_string(),
-                                },
-                            )
-                        }
-                    };
-                    Some(ProtoTransactionWithSimulationResult {
-                        transaction: Some(transaction),
-                        simulation: Some(simulation),
-                    })
-                })
-                .collect()
-        };
+            })
+            .collect();
 
         if transactions_with_simulation.is_empty() {
             saturating_add_assign!(pbs_stats.num_empty_tx_batches, 1);
@@ -632,115 +450,6 @@ impl PbsEngineStage {
         Ok(())
     }
 
-    async fn delay_packet_batches(
-        mut sigverified_receiver: UnboundedReceiver<BankingPacketBatch>,
-        banking_packet_sender: BankingPacketSender,
-        pbs_sender: UnboundedSender<(BankingPacketBatch, Instant)>,
-        exit: Arc<AtomicBool>,
-        mut slot_boundary_receiver: tokio::sync::watch::Receiver<SlotBoundaryStatus>,
-    ) {
-        const SLOT_START_DELAY: Duration = Duration::from_millis(20);
-        const DELAY_PACKET_BATCHES: Duration = Duration::from_millis(DELAY_PACKET_BATCHES_MS);
-        let mut delayed_queue: DelayQueue<BankingPacketBatch> = DelayQueue::new();
-
-        let mut status = match *slot_boundary_receiver.borrow_and_update() {
-            SlotBoundaryStatus::StandBy => RunningLeaderStatus::StandBy,
-            SlotBoundaryStatus::InProgress => RunningLeaderStatus::InProgress,
-        };
-
-        // The maximum duration for a sleep, so it will not wake up
-        let slot_start_delay = tokio::time::sleep(Duration::from_secs(68719476734));
-        tokio::pin!(slot_start_delay);
-
-        while !exit.load(Ordering::Relaxed) {
-            tokio::select! {
-                biased;
-
-                maybe_slot_boundary_changed = slot_boundary_receiver.changed() => {
-                    if maybe_slot_boundary_changed.is_err() {
-                        error!("slot boundary checker sender closed");
-                        break;
-                    }
-                    status = match (status, *slot_boundary_receiver.borrow_and_update()) {
-                        (RunningLeaderStatus::StandBy, SlotBoundaryStatus::InProgress) | (RunningLeaderStatus::Completed, SlotBoundaryStatus::InProgress) =>
-                        {
-                            slot_start_delay.as_mut().reset(Instant::now() + SLOT_START_DELAY);
-                            RunningLeaderStatus::BankStart
-                        },
-                        (RunningLeaderStatus::BankStart, SlotBoundaryStatus::StandBy) => RunningLeaderStatus::StandBy,
-                        (RunningLeaderStatus::InProgress, SlotBoundaryStatus::StandBy) => RunningLeaderStatus::Completed,
-                        (_, _) => status,
-                    };
-                }
-
-                _ = &mut slot_start_delay, if matches!(status, RunningLeaderStatus::BankStart) => {
-                    status = RunningLeaderStatus::InProgress;
-                }
-
-                Some(packet_batch) = delayed_queue.next(), if matches!(status, RunningLeaderStatus::InProgress | RunningLeaderStatus::Completed) => {
-                    match packet_batch {
-                        Ok(packet_batch) => {
-                            if banking_packet_sender.send(packet_batch.into_inner()).is_err() {
-                                error!("banking packet receiver closed");
-                                break;
-                            }
-                            if delayed_queue.is_empty() && matches!(status, RunningLeaderStatus::Completed) {
-                                status = RunningLeaderStatus::StandBy;
-                            }
-                        }
-                        Err(err) => {
-                            warn!("delayed_queue timer error: {}", err.to_string());
-                        }
-                    }
-                }
-
-                Some(packet_batch) = sigverified_receiver.recv() => {
-                    let deadline = Instant::now() + DELAY_PACKET_BATCHES;
-                    delayed_queue.insert_at(packet_batch.clone(), deadline);
-                    if pbs_sender.send((packet_batch, deadline)).is_err() {
-                        error!("pbs receiver closed");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    fn start_slot_boundary_checker(
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        leader_status_sender: tokio::sync::watch::Sender<SlotBoundaryStatus>,
-        exit: Arc<AtomicBool>,
-    ) -> TokioJoinHandle<()> {
-        tokio::spawn(Self::slot_boundary_checker(
-            poh_recorder,
-            leader_status_sender,
-            exit,
-        ))
-    }
-
-    async fn slot_boundary_checker(
-        poh_recorder: Arc<RwLock<PohRecorder>>,
-        leader_status_sender: tokio::sync::watch::Sender<SlotBoundaryStatus>,
-        exit: Arc<AtomicBool>,
-    ) {
-        const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
-        let mut slot_boundary_check_tick = interval(SLOT_BOUNDARY_CHECK_PERIOD);
-
-        while !exit.load(Ordering::Relaxed) {
-            slot_boundary_check_tick.tick().await;
-            let recent_status =
-                SlotBoundaryStatus::from(is_poh_recorder_in_progress(&poh_recorder));
-            leader_status_sender.send_if_modified(|status| {
-                if *status != recent_status {
-                    *status = recent_status;
-                    true
-                } else {
-                    false
-                }
-            });
-        }
-    }
-
     pub fn is_valid_pbs_config(config: &PbsConfig) -> bool {
         if config.pbs_url.is_empty() {
             warn!("can't connect to pbs. missing pbs_url.");
@@ -756,198 +465,4 @@ impl PbsEngineStage {
         }
         true
     }
-}
-
-fn sanitized_to_proto_sanitized(tx: SanitizedTransaction) -> Option<ProtoSanitizedTransaction> {
-    let versioned_transaction = bincode::serialize(&tx.to_versioned_transaction()).ok()?;
-    let message_hash = tx.message_hash().to_bytes().to_vec();
-    let loaded_addresses = bincode::serialize(&tx.get_loaded_addresses()).ok()?;
-
-    Some(ProtoSanitizedTransaction {
-        versioned_transaction,
-        message_hash,
-        loaded_addresses,
-    })
-}
-
-fn inner_instructions_to_proto(
-    inner_instructions: Option<&InnerInstructionsList>,
-) -> ProtoSimulationResult {
-    use forge_protos::proto::pbs::{
-        InnerInstruction as ProtoInnerInstruction, InnerInstructions as ProtoInnerInstructions,
-    };
-
-    ProtoSimulationResult {
-        inner_instructions: inner_instructions
-            .into_iter()
-            .flatten()
-            .map(|inner_instructions| ProtoInnerInstructions {
-                instructions: inner_instructions
-                    .iter()
-                    .map(|ixn| ProtoInnerInstruction {
-                        program_id_index: ixn.instruction.program_id_index as u32,
-                        accounts: ixn.instruction.accounts.clone(),
-                        data: ixn.instruction.data.clone(),
-                        stack_height: ixn.stack_height as u32,
-                    })
-                    .collect(),
-            })
-            .collect(),
-        inner_instructions_none: inner_instructions.is_none(),
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-enum RunningLeaderStatus {
-    #[default]
-    StandBy,
-    BankStart,
-    InProgress,
-    Completed,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-enum SlotBoundaryStatus {
-    #[default]
-    StandBy,
-    InProgress,
-}
-
-impl From<bool> for SlotBoundaryStatus {
-    fn from(value: bool) -> Self {
-        if value {
-            Self::InProgress
-        } else {
-            Self::StandBy
-        }
-    }
-}
-
-fn is_poh_recorder_in_progress(poh_recorder: &Arc<RwLock<PohRecorder>>) -> bool {
-    let poh_recorder = poh_recorder.read().unwrap();
-    poh_recorder
-        .bank_start()
-        .map(|bank_start| bank_start.should_working_bank_still_be_processing_txs())
-        .unwrap_or_default()
-}
-
-struct SubscriptionFilters {
-    stream_all: bool,
-    account_include: Vec<Pubkey>,
-    account_exclude: Vec<Pubkey>,
-    account_required: Vec<Pubkey>,
-}
-
-impl TryFrom<SubscriptionFiltersResponse> for SubscriptionFilters {
-    type Error = PbsError;
-    fn try_from(value: SubscriptionFiltersResponse) -> Result<Self, Self::Error> {
-        let SubscriptionFiltersResponse {
-            stream_all,
-            account_include,
-            account_exclude,
-            account_required,
-        } = value;
-
-        Ok(Self {
-            stream_all: stream_all.unwrap_or_default(),
-            account_include: decode_pubkeys_into_vec(account_include)?,
-            account_exclude: decode_pubkeys_into_vec(account_exclude)?,
-            account_required: decode_pubkeys_into_vec(account_required)?,
-        })
-    }
-}
-
-fn decode_pubkeys_into_vec(pubkeys: Vec<Vec<u8>>) -> Result<Vec<Pubkey>, PbsError> {
-    let mut vec: Vec<_> = pubkeys
-        .into_iter()
-        .map(Pubkey::try_from)
-        .collect::<Result<_, _>>()
-        .map_err(|_| PbsError::SimulationSettingsError)?;
-    vec.sort();
-    Ok(vec)
-}
-
-impl SubscriptionFilters {
-    pub fn is_tx_have_to_be_processed(&self, transaction: &SanitizedTransaction) -> bool {
-        if self.stream_all {
-            return true;
-        }
-
-        let accounts = transaction.message().account_keys();
-
-        if !self.account_include.is_empty()
-            && accounts
-                .iter()
-                .all(|pubkey| self.account_include.binary_search(pubkey).is_err())
-        {
-            return false;
-        }
-
-        if !self.account_exclude.is_empty()
-            && accounts
-                .iter()
-                .any(|pubkey| self.account_exclude.binary_search(pubkey).is_ok())
-        {
-            return false;
-        }
-
-        if !self.account_required.is_empty() {
-            let mut other: Vec<&Pubkey> = accounts.iter().collect();
-
-            let is_subset = if self.account_required.len() <= other.len() {
-                other.sort();
-                self.account_required
-                    .iter()
-                    .all(|pubkey| other.binary_search(&pubkey).is_ok())
-            } else {
-                false
-            };
-
-            if !is_subset {
-                return false;
-            }
-        }
-
-        true
-    }
-}
-
-fn simulate(
-    tx: &SanitizedTransaction,
-    bank: &Bank,
-) -> LoadAndExecuteBundleResult<ProtoSimulationResult> {
-    const MAX_BUNDLE_SIMULATION_TIME: Duration = Duration::from_millis(50);
-
-    let sanitized_bundle = SanitizedBundle {
-        bundle_id: derive_bundle_id_from_sanitized_transactions(from_ref(tx)),
-        transactions: vec![tx.clone()],
-    };
-
-    let bundle_execution_result = load_and_execute_bundle(
-        bank,
-        &sanitized_bundle,
-        MAX_PROCESSING_AGE,
-        &MAX_BUNDLE_SIMULATION_TIME,
-        true,
-        false,
-        false,
-        false,
-        &None,
-        true,
-        None,
-        &vec![None],
-        &vec![None],
-    );
-
-    bundle_execution_result.result().clone().map(|_| {
-        let inner_instructions = bundle_execution_result
-            .bundle_transaction_results()
-            .first()
-            .and_then(|bundle_execution_result| bundle_execution_result.execution_results().first())
-            .and_then(|transaction_execution_result| transaction_execution_result.details())
-            .and_then(|transaction_execution_details| {
-                transaction_execution_details.inner_instructions.as_ref()
-            });
-        inner_instructions_to_proto(inner_instructions)
-    })
 }

--- a/core/src/pbs/pbs_stage.rs
+++ b/core/src/pbs/pbs_stage.rs
@@ -344,7 +344,7 @@ impl PbsEngineStage {
             })?;
 
         info!("connected to pbs stream");
-        while exit.load(Ordering::Relaxed) {
+        while !exit.load(Ordering::Relaxed) {
             tokio::select! {
                 biased;
 

--- a/core/src/pbs/pbs_stage.rs
+++ b/core/src/pbs/pbs_stage.rs
@@ -5,7 +5,7 @@ use {
         pbs::{interceptor::AuthInterceptor, PbsError},
         proto_packet_to_packet,
     },
-    crossbeam_channel::{SendError, Sender},
+    crossbeam_channel::Sender,
     forge_protos::proto::pbs::{
         pbs_validator_client::PbsValidatorClient, BundlesResponse,
         SanitizedTransaction as ProtoSanitizedTransaction, SanitizedTransactionRequest,
@@ -13,18 +13,13 @@ use {
     futures::StreamExt,
     prost_types::Timestamp,
     reqwest::header,
-    solana_perf::{packet::PacketBatch, sigverify::PacketError},
+    solana_perf::packet::PacketBatch,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{
-        packet::Packet,
         saturating_add_assign,
-        short_vec::decode_shortu16_len,
-        signature::Signature,
         transaction::{MessageHash, SanitizedTransaction},
     },
     std::{
-        collections::HashSet,
-        mem::size_of,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Mutex, RwLock,
@@ -51,8 +46,6 @@ const CONNECTION_TIMEOUT_S: u64 = 10;
 const CONNECTION_BACKOFF_S: u64 = 5;
 
 const REQUEST_TIMEOUT_MS: u64 = 300;
-
-const BUNDLE_LIFE_TIME_IN_DELAYER_MS: u64 = 400;
 
 #[derive(Default)]
 struct PbsStageStats {
@@ -170,12 +163,10 @@ impl PbsEngineStage {
         );
 
         let (pbs_sender, mut pbs_receiver) = tokio::sync::mpsc::unbounded_channel();
-        let (drop_packet_sender, bundle_receiver) = tokio::sync::mpsc::unbounded_channel();
         let delayer_join_handle = Self::start_delayer(
             forwarder_receiver,
             banking_packet_sender,
             pbs_sender,
-            bundle_receiver,
             exit.clone(),
         );
 
@@ -196,7 +187,6 @@ impl PbsEngineStage {
                 &pbs_config,
                 &bundle_tx,
                 &mut pbs_receiver,
-                &drop_packet_sender,
                 &is_pbs_active,
                 &exit,
                 &bank_forks,
@@ -269,14 +259,12 @@ impl PbsEngineStage {
         sigverified_receiver: UnboundedReceiver<BankingPacketBatch>,
         banking_packet_sender: BankingPacketSender,
         pbs_sender: UnboundedSender<(BankingPacketBatch, Instant)>,
-        bundle_receiver: UnboundedReceiver<Vec<Signature>>,
         exit: Arc<AtomicBool>,
     ) -> TokioJoinHandle<()> {
         tokio::spawn(Self::delay_packet_batches(
             sigverified_receiver,
             banking_packet_sender,
             pbs_sender,
-            bundle_receiver,
             exit,
         ))
     }
@@ -286,7 +274,6 @@ impl PbsEngineStage {
         global_config: &Arc<Mutex<PbsConfig>>,
         bundle_tx: &Sender<Vec<PacketBundle>>,
         receiver: &mut UnboundedReceiver<(BankingPacketBatch, Instant)>,
-        drop_packet_sender: &UnboundedSender<Vec<Signature>>,
         is_pbs_active: &Arc<AtomicBool>,
         exit: &Arc<AtomicBool>,
         bank_forks: &Arc<RwLock<BankForks>>,
@@ -329,7 +316,6 @@ impl PbsEngineStage {
             pbs_client,
             bundle_tx,
             receiver,
-            drop_packet_sender,
             is_pbs_active,
             exit,
             bank_forks,
@@ -344,7 +330,6 @@ impl PbsEngineStage {
         mut client: PbsValidatorClient<InterceptedService<Channel, AuthInterceptor>>,
         bundle_tx: &Sender<Vec<PacketBundle>>,
         receiver: &mut UnboundedReceiver<(BankingPacketBatch, Instant)>,
-        drop_packet_sender: &UnboundedSender<Vec<Signature>>,
         is_pbs_active: &Arc<AtomicBool>,
         exit: &Arc<AtomicBool>,
         bank_forks: &Arc<RwLock<BankForks>>,
@@ -374,7 +359,7 @@ impl PbsEngineStage {
                 biased;
 
                 maybe_bundles = bundles_stream.message() => {
-                    Self::handle_maybe_bundles(maybe_bundles, bundle_tx, drop_packet_sender, &mut pbs_stats)?;
+                    Self::handle_maybe_bundles(maybe_bundles, bundle_tx, &mut pbs_stats)?;
                 }
 
                 Some((packet_batch, deadline)) = receiver.recv() => {
@@ -401,7 +386,6 @@ impl PbsEngineStage {
     fn handle_maybe_bundles(
         maybe_bundles_response: Result<Option<BundlesResponse>, Status>,
         bundle_sender: &Sender<Vec<PacketBundle>>,
-        delayer_sender: &UnboundedSender<Vec<Signature>>,
         pbs_stats: &mut PbsStageStats,
     ) -> Result<(), PbsError> {
         let bundles_response = maybe_bundles_response?.ok_or(PbsError::GrpcStreamDisconnected)?;
@@ -428,30 +412,9 @@ impl PbsEngineStage {
             bundles.iter().map(|bundle| bundle.batch.len() as u64).sum()
         );
 
-        Self::send_bundles_to_delayer(&bundles, delayer_sender)?;
-
         // NOTE: bundles are sanitized in bundle_sanitizer module
         bundle_sender
             .send(bundles)
-            .map_err(|_| PbsError::PacketForwardError)
-    }
-
-    fn send_bundles_to_delayer(
-        bundles: &[PacketBundle],
-        delayer_sender: &UnboundedSender<Vec<Signature>>,
-    ) -> Result<(), PbsError> {
-        let signatures = bundles
-            .iter()
-            .flat_map(|bundle| {
-                bundle
-                    .batch
-                    .iter()
-                    .filter_map(|packet| extract_first_signature(packet).ok())
-            })
-            .collect();
-
-        delayer_sender
-            .send(signatures)
             .map_err(|_| PbsError::PacketForwardError)
     }
 
@@ -520,39 +483,19 @@ impl PbsEngineStage {
         mut sigverified_receiver: UnboundedReceiver<BankingPacketBatch>,
         banking_packet_sender: BankingPacketSender,
         pbs_sender: UnboundedSender<(BankingPacketBatch, Instant)>,
-        mut bundle_receiver: UnboundedReceiver<Vec<Signature>>,
         exit: Arc<AtomicBool>,
     ) {
         const DELAY_PACKET_BATCHES: Duration = Duration::from_millis(REQUEST_TIMEOUT_MS);
-
         let mut delayed_queue: DelayQueue<BankingPacketBatch> = DelayQueue::new();
-
-        let mut bundles: HashSet<Signature> = HashSet::new();
-        let mut bundles_expirations: DelayQueue<Signature> = DelayQueue::new();
 
         while !exit.load(Ordering::Relaxed) {
             tokio::select! {
                 biased;
 
-                Some(signatures) = bundle_receiver.recv() => {
-                    Self::handle_bundles_in_delayer(signatures, &mut bundles, &mut bundles_expirations);
-                }
-
-                Some(maybe_signature) = bundles_expirations.next() => {
-                    match maybe_signature {
-                        Ok(signature) => {
-                            bundles.remove(&signature.into_inner());
-                        }
-                        Err(err) => {
-                            warn!("delayed_queue timer error: {}", err.to_string());
-                        }
-                    }
-                }
-
-                Some(maybe_packet_batch) = delayed_queue.next() => {
-                    match maybe_packet_batch {
+                Some(packet_batch) = delayed_queue.next() => {
+                    match packet_batch {
                         Ok(packet_batch) => {
-                            if let Err(_) = Self::handle_delayed_banking_packet_batch(packet_batch.into_inner(), &banking_packet_sender, &bundles) {
+                            if let Err(_) = banking_packet_sender.send(packet_batch.into_inner()) {
                                 error!("banking packet receiver closed");
                                 break;
                             }
@@ -572,57 +515,6 @@ impl PbsEngineStage {
                     }
                 }
             }
-        }
-    }
-
-    fn handle_delayed_banking_packet_batch(
-        banking_packet_batch: BankingPacketBatch,
-        banking_packet_sender: &BankingPacketSender,
-        bundles: &HashSet<Signature>,
-    ) -> Result<(), SendError<BankingPacketBatch>> {
-        let exclude: Vec<_> = banking_packet_batch
-            .0
-            .iter()
-            .enumerate()
-            .filter_map(|(pos_outer, batch)| {
-                let positions: Vec<_> = batch
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(pos_inner, packet)| {
-                        let signature = extract_first_signature(packet).ok()?;
-                        bundles.contains(&signature).then_some(pos_inner)
-                    })
-                    .collect();
-                (!positions.is_empty()).then_some((pos_outer, positions))
-            })
-            .collect();
-
-        if exclude.is_empty() {
-            return banking_packet_sender.send(banking_packet_batch);
-        }
-
-        let (mut banking_packet_batch, stats) = banking_packet_batch.as_ref().clone();
-        for (outer, inner) in exclude {
-            let batch = &mut banking_packet_batch[outer];
-            for pos in inner {
-                batch[pos].meta_mut().set_discard(true);
-            }
-        }
-
-        banking_packet_sender.send(BankingPacketBatch::new((banking_packet_batch, stats)))
-    }
-
-    fn handle_bundles_in_delayer(
-        signatures: Vec<Signature>,
-        bundles: &mut HashSet<Signature>,
-        expirations: &mut DelayQueue<Signature>,
-    ) {
-        for signature in signatures {
-            expirations.insert(
-                signature.clone(),
-                Duration::from_millis(BUNDLE_LIFE_TIME_IN_DELAYER_MS),
-            );
-            bundles.insert(signature);
         }
     }
 
@@ -653,28 +545,4 @@ fn sanitized_to_proto_sanitized(tx: SanitizedTransaction) -> Option<ProtoSanitiz
         message_hash,
         loaded_addresses,
     })
-}
-
-fn extract_first_signature(packet: &Packet) -> Result<Signature, PacketError> {
-    // should have at least 1 signature and sig lengths
-    let _ = 1usize
-        .checked_add(size_of::<Signature>())
-        .filter(|v| *v <= packet.meta().size)
-        .ok_or(PacketError::InvalidLen)?;
-
-    // read the length of Transaction.signatures (serialized with short_vec)
-    let (_sig_len_untrusted, sig_start) = packet
-        .data(..)
-        .and_then(|bytes| decode_shortu16_len(bytes).ok())
-        .ok_or(PacketError::InvalidShortVec)?;
-
-    let sig_end = sig_start
-        .checked_add(size_of::<Signature>())
-        .ok_or(PacketError::InvalidLen)?;
-
-    packet
-        .data(sig_start..sig_end)
-        .ok_or(PacketError::InvalidLen)?
-        .try_into()
-        .map_err(|_| PacketError::InvalidLen)
 }

--- a/core/src/pbs/slot_boundary.rs
+++ b/core/src/pbs/slot_boundary.rs
@@ -1,0 +1,82 @@
+use {
+    solana_poh::poh_recorder::PohRecorder,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        time::Duration,
+    },
+    tokio::{sync::watch, task::JoinHandle, time::interval},
+};
+
+const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
+
+pub struct SlotBoundaryChecker {
+    poh_recorder: Arc<RwLock<PohRecorder>>,
+    leader_status_updater: watch::Sender<SlotBoundaryStatus>,
+    exit: Arc<AtomicBool>,
+}
+
+impl SlotBoundaryChecker {
+    pub fn start(
+        poh_recorder: Arc<RwLock<PohRecorder>>,
+        exit: Arc<AtomicBool>,
+    ) -> (watch::Receiver<SlotBoundaryStatus>, JoinHandle<()>) {
+        let (leader_status_updater, leader_status_watch) =
+            watch::channel(SlotBoundaryStatus::StandBy);
+        let actor = SlotBoundaryChecker {
+            poh_recorder,
+            leader_status_updater,
+            exit,
+        };
+        (
+            leader_status_watch,
+            tokio::spawn(run_slot_boundary_checker(actor)),
+        )
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum SlotBoundaryStatus {
+    #[default]
+    StandBy,
+    InProgress,
+}
+
+async fn run_slot_boundary_checker(actor: SlotBoundaryChecker) {
+    let SlotBoundaryChecker {
+        poh_recorder,
+        leader_status_updater,
+        exit,
+    } = actor;
+
+    let mut check_tick = interval(SLOT_BOUNDARY_CHECK_PERIOD);
+    while !exit.load(Ordering::Relaxed) {
+        check_tick.tick().await;
+        let recent = SlotBoundaryStatus::from(poh_recorder.as_ref());
+        leader_status_updater.send_if_modified(|status| {
+            if *status != recent {
+                *status = recent;
+                true
+            } else {
+                false
+            }
+        });
+    }
+}
+
+impl From<&RwLock<PohRecorder>> for SlotBoundaryStatus {
+    fn from(poh_recorder: &RwLock<PohRecorder>) -> Self {
+        let poh_recorder = poh_recorder.read().unwrap();
+        if poh_recorder
+            .bank_start()
+            .map(|bank_start| bank_start.should_working_bank_still_be_processing_txs())
+            .unwrap_or_default()
+        {
+            Self::InProgress
+        } else {
+            Self::StandBy
+        }
+    }
+}

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -221,6 +221,7 @@ impl Tpu {
         let pbs_stage = PbsEngineStage::new(
             pbs_config,
             bundle_sender,
+            cluster_info.clone(),
             pbs_receiver,
             non_vote_sender,
             exit.clone(),

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -29,7 +29,9 @@ use {
     },
     solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
     solana_rpc::{
-        optimistically_confirmed_bank_tracker::BankNotificationSender,
+        optimistically_confirmed_bank_tracker::{
+            BankNotificationSender,
+        },
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache},

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -29,9 +29,7 @@ use {
     },
     solana_poh::poh_recorder::{PohRecorder, WorkingBankEntry},
     solana_rpc::{
-        optimistically_confirmed_bank_tracker::{
-            BankNotificationSender,
-        },
+        optimistically_confirmed_bank_tracker::BankNotificationSender,
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{bank_forks::BankForks, prioritization_fee_cache::PrioritizationFeeCache},
@@ -227,6 +225,7 @@ impl Tpu {
             non_vote_sender,
             exit.clone(),
             bank_forks.clone(),
+            poh_recorder.clone(),
         );
 
         let cluster_info_vote_listener = ClusterInfoVoteListener::new(

--- a/forge-protos/protos/pbs.proto
+++ b/forge-protos/protos/pbs.proto
@@ -30,7 +30,16 @@ message SanitizedTransactionRequest {
   repeated SanitizedTransaction transactions = 2;
 }
 
+message SimulationSettingsRequest {}
+
+message SimulationSettingsResponse {
+  repeated bytes account_include = 1;
+  repeated bytes account_exclude = 2;
+  repeated bytes account_required = 3;
+}
+
 /// Validators can connect to PBS to send packets and receive and bundles.
 service PbsValidator {
   rpc SubscribeSanitized (stream SanitizedTransactionRequest) returns (stream BundlesResponse) {}
+  rpc GetSimulationSettings (SimulationSettingsRequest) returns (SimulationSettingsResponse) {}
 }

--- a/forge-protos/protos/pbs.proto
+++ b/forge-protos/protos/pbs.proto
@@ -25,15 +25,54 @@ message SanitizedTransaction {
   bytes loaded_addresses = 3;
 }
 
+message TransactionWithSimulationResult {
+  SanitizedTransaction transaction = 1;
+  oneof simulation {
+      TransactionError transaction_error = 2;
+      BundleError bundle_error = 3;
+      SimulationResult simulation_result = 4;
+  }
+}
+
+message TransactionError {
+  string err = 1;
+}
+
+enum BundleError {
+  BUNDLE_ERROR_UNSPECIFIED = 0;
+  BUNDLE_ERROR_PROCESSING_TIME_EXCEEDED = 1;
+  BUNDLE_ERROR_LOCK_ERROR = 2;
+  BUNDLE_ERROR_INVALID_PRE_OR_POST_ACCOUNTS = 3;
+}
+
+message SimulationResult {
+  repeated InnerInstructions inner_instructions = 1;
+  bool inner_instructions_none = 2;
+}
+
+message InnerInstructions {
+  repeated InnerInstruction instructions = 1;
+}
+
+message InnerInstruction {
+  uint32 program_id_index = 1;
+  bytes accounts = 2;
+  bytes data = 3;
+
+  // Invocation stack height of an inner instruction.
+  uint32 stack_height = 4;
+}
+
 message SanitizedTransactionRequest {
   google.protobuf.Timestamp ts = 1;
   repeated SanitizedTransaction transactions = 2;
+  repeated TransactionWithSimulationResult transactions_with_simulation = 3;
 }
 
-message SimulationSettingsRequest {}
+message SubscriptionFiltersRequest {}
 
-message SimulationSettingsResponse {
-  optional bool simulate_all = 1;
+message SubscriptionFiltersResponse {
+  optional bool stream_all = 1;
   repeated bytes account_include = 2;
   repeated bytes account_exclude = 3;
   repeated bytes account_required = 4;
@@ -42,5 +81,5 @@ message SimulationSettingsResponse {
 /// Validators can connect to PBS to send packets and receive and bundles.
 service PbsValidator {
   rpc SubscribeSanitized (stream SanitizedTransactionRequest) returns (stream BundlesResponse) {}
-  rpc GetSimulationSettings (SimulationSettingsRequest) returns (SimulationSettingsResponse) {}
+  rpc GetSubscriptionFilters (SubscriptionFiltersRequest) returns (SubscriptionFiltersResponse) {}
 }

--- a/forge-protos/protos/pbs.proto
+++ b/forge-protos/protos/pbs.proto
@@ -33,9 +33,10 @@ message SanitizedTransactionRequest {
 message SimulationSettingsRequest {}
 
 message SimulationSettingsResponse {
-  repeated bytes account_include = 1;
-  repeated bytes account_exclude = 2;
-  repeated bytes account_required = 3;
+  optional bool simulate_all = 1;
+  repeated bytes account_include = 2;
+  repeated bytes account_exclude = 3;
+  repeated bytes account_required = 4;
 }
 
 /// Validators can connect to PBS to send packets and receive and bundles.

--- a/forge-protos/protos/pbs.proto
+++ b/forge-protos/protos/pbs.proto
@@ -65,7 +65,7 @@ message InnerInstruction {
 
 message SanitizedTransactionRequest {
   google.protobuf.Timestamp ts = 1;
-  repeated SanitizedTransaction transactions = 2;
+  reserved 2;
   repeated TransactionWithSimulationResult transactions_with_simulation = 3;
 }
 


### PR DESCRIPTION
Разнёс код по модулям, хотя delayer и pbs_stage всё ещё достаточно большие.

Перенес симуляцию в delayer. Она делается чанками по 20 шт. Если симуляция не успевает до simulation_deadline, sanitized_transactions отправляются в pbs без результатов симуляции (TODO - будут правки в pbs, что если нет результатов симуляции, то это нормально).

Также реализовано решение, что пакеты из bundle удаляются из обработки для banking.
