### PR TITLE
Cache simulation result during leader slots

### DIFF
--- a/core/src/pbs/mod.rs
+++ b/core/src/pbs/mod.rs
@@ -12,6 +12,7 @@ mod forwarder;
 mod grpc;
 mod interceptor;
 pub mod pbs_stage;
+mod simulation_result_cache;
 mod slot_boundary;
 
 #[derive(Error, Debug)]

--- a/core/src/pbs/simulation_result_cache.rs
+++ b/core/src/pbs/simulation_result_cache.rs
@@ -1,0 +1,45 @@
+use {
+    crate::pbs::grpc::SanitizedTransactionWithSimulationResult,
+    solana_bundle::bundle_execution::LoadAndExecuteBundleError,
+    solana_sdk::{hash::Hash, transaction::SanitizedTransaction},
+    std::collections::HashSet,
+};
+
+pub struct SimulationResultCache {
+    cache: HashSet<Hash>,
+}
+
+impl SimulationResultCache {
+    pub fn new() -> Self {
+        Self {
+            cache: HashSet::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.cache.clear();
+    }
+
+    pub fn contains(&self, sanitized_transaction: &SanitizedTransaction) -> bool {
+        let mut message = sanitized_transaction.to_versioned_transaction().message;
+        message.set_recent_blockhash(Default::default());
+        self.cache.contains(&message.hash())
+    }
+
+    pub fn populate_with_failed_simulations(
+        &mut self,
+        simulation_results: &[SanitizedTransactionWithSimulationResult],
+    ) {
+        self.cache.extend(simulation_results.iter().filter_map(|v| {
+            if let Some(Err(LoadAndExecuteBundleError::TransactionError { .. })) =
+                v.simulation_result
+            {
+                let mut message = v.transaction.to_versioned_transaction().message;
+                message.set_recent_blockhash(Default::default());
+                Some(message.hash())
+            } else {
+                None
+            }
+        }))
+    }
+}

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -69,7 +69,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         block_production_method: config.block_production_method.clone(),
         generator_config: config.generator_config.clone(),
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,
-        // shred_receiver_address: config.shred_receiver_address.clone(),
+        shred_receiver_address: config.shred_receiver_address.clone(),
         preallocated_bundle_cost: config.preallocated_bundle_cost,
         pbs_config: config.pbs_config.clone(),
     }


### PR DESCRIPTION
do not simulate tx with the same message hash (without blockhash)